### PR TITLE
Add Docker Swarm Patroni cluster example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# test
+# PostgreSQL Cluster with Patroni
+
+This repository provides a sample Docker Swarm stack to run a PostgreSQL
+cluster managed by Patroni. The cluster consists of a master node and
+replicas with automatic failover.
+
+## Features
+
+- **Replication**: Patroni ensures that one node is elected as the leader
+  (master) while the remaining nodes act as replicas.
+- **Failover**: When the master node fails, Patroni automatically
+  promotes one of the replicas.
+- **Easy scaling**: Adjust the total number of nodes by changing a single
+  environment variable when deploying the stack.
+
+## Usage
+
+1. Initialize a Docker Swarm if you have not done so already:
+
+   ```bash
+   docker swarm init
+   ```
+
+2. Deploy the stack using the provided `docker-stack.yml`. The number of
+   nodes can be configured through the `PG_NODES` variable. By default it
+   starts four nodes (one master and three replicas):
+
+   ```bash
+   PG_NODES=4 docker stack deploy -c docker-stack.yml pg-cluster
+   ```
+
+   Change `PG_NODES` to scale the cluster with a single line.
+
+3. Verify that the services are running:
+
+   ```bash
+   docker stack ps pg-cluster
+   ```
+
+The stack uses the [Spilo](https://github.com/zalando/spilo) image which
+bundles PostgreSQL and Patroni. An `etcd` service is included to provide
+Patroni with a distributed configuration store.
+
+To remove the stack:
+
+```bash
+docker stack rm pg-cluster
+```
+
+## Notes
+
+- The stack creates an overlay network named `pgnet` for inter-service
+  communication.
+- Persistent storage volumes are not configured in this example. For
+  production usage you should add volumes for data persistence.

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+
+services:
+  pg_cluster:
+    image: ghcr.io/zalando/spilo-15:2.1-p6
+    environment:
+      CLUSTER_NAME: my-postgres
+      CLUSTER_SCOPE: my-postgres
+      SCOPE: my-postgres
+      PATRONI_POSTGRESQL_DATA_DIR: /home/postgres/pgdata/pgroot/data
+      PATRONI_KUBERNETES_USE_ENDPOINTS: 'false'
+      PATRONI_LOG_LEVEL: INFO
+      PATRONI_ETCD_HOSTS: etcd:2379
+      PATRONI_REPLICATION_USERNAME: replicator
+      PATRONI_REPLICATION_PASSWORD: replpassword
+      PATRONI_SUPERUSER_PASSWORD: adminpassword
+    deploy:
+      replicas: ${PG_NODES:-4}
+      restart_policy:
+        condition: on-failure
+    networks:
+      - pgnet
+
+  etcd:
+    image: quay.io/coreos/etcd:v3.5
+    environment:
+      ETCD_LISTEN_CLIENT_URLS: http://0.0.0.0:2379
+      ETCD_ADVERTISE_CLIENT_URLS: http://etcd:2379
+    deploy:
+      placement:
+        constraints: [node.role == manager]
+    networks:
+      - pgnet
+
+networks:
+  pgnet:
+    driver: overlay


### PR DESCRIPTION
## Summary
- create Docker Swarm stack to run Patroni-based PostgreSQL cluster
- document how to deploy and scale the cluster

## Testing
- `pytest -q`