### PR TITLE
Switch to official PostgreSQL image with Patroni

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM postgres:15
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3-pip && \
+    pip3 install --no-cache-dir patroni[etcd] && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY patroni-entrypoint.sh /usr/local/bin/patroni-entrypoint.sh
+RUN chmod +x /usr/local/bin/patroni-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/patroni-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -15,13 +15,19 @@ replicas with automatic failover.
 
 ## Usage
 
-1. Initialize a Docker Swarm if you have not done so already:
+1. Build the `postgres-patroni` image from the provided `Dockerfile`:
+
+   ```bash
+   docker build -t postgres-patroni .
+   ```
+
+2. Initialize a Docker Swarm if you have not done so already:
 
    ```bash
    docker swarm init
    ```
 
-2. Deploy the stack using the provided `docker-stack.yml`. The number of
+3. Deploy the stack using the provided `docker-stack.yml`. The number of
    nodes can be configured through the `PG_NODES` variable. By default it
    starts four nodes (one master and three replicas):
 
@@ -31,15 +37,15 @@ replicas with automatic failover.
 
    Change `PG_NODES` to scale the cluster with a single line.
 
-3. Verify that the services are running:
+4. Verify that the services are running:
 
    ```bash
    docker stack ps pg-cluster
    ```
 
-The stack uses the [Spilo](https://github.com/zalando/spilo) image which
-bundles PostgreSQL and Patroni. An `etcd` service is included to provide
-Patroni with a distributed configuration store.
+The stack uses a custom image built from the official `postgres` image
+with Patroni installed. An `etcd` service is included to provide Patroni
+with a distributed configuration store.
 
 To remove the stack:
 

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -2,13 +2,10 @@ version: '3.8'
 
 services:
   pg_cluster:
-    image: ghcr.io/zalando/spilo-15:2.1-p6
+    image: postgres-patroni:latest
     environment:
-      CLUSTER_NAME: my-postgres
-      CLUSTER_SCOPE: my-postgres
-      SCOPE: my-postgres
-      PATRONI_POSTGRESQL_DATA_DIR: /home/postgres/pgdata/pgroot/data
-      PATRONI_KUBERNETES_USE_ENDPOINTS: 'false'
+      PATRONI_SCOPE: my-postgres
+      PATRONI_POSTGRESQL_DATA_DIR: /var/lib/postgresql/data
       PATRONI_LOG_LEVEL: INFO
       PATRONI_ETCD_HOSTS: etcd:2379
       PATRONI_REPLICATION_USERNAME: replicator

--- a/patroni-entrypoint.sh
+++ b/patroni-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# Default path for Patroni configuration directory
+export PATRONI_POSTGRESQL_DATA_DIR=${PATRONI_POSTGRESQL_DATA_DIR:-/var/lib/postgresql/data}
+
+exec patroni


### PR DESCRIPTION
## Summary
- add `Dockerfile` that installs Patroni on top of the official PostgreSQL image
- use new `postgres-patroni` image in `docker-stack.yml`
- update README with build and deploy instructions

## Testing
- `docker --version` *(fails: command not found)*