### PR TITLE
Add mirror option for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM postgres:15
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3-pip && \
+# Allow overriding the Debian mirror for environments with limited
+# connectivity. Specify `--build-arg APT_MIRROR=<mirror>` when building
+# to choose a different mirror.
+ARG APT_MIRROR=deb.debian.org
+RUN sed -i "s|deb.debian.org|${APT_MIRROR}|g" /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends --fix-missing python3-pip && \
     pip3 install --no-cache-dir patroni[etcd] && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 COPY patroni-entrypoint.sh /usr/local/bin/patroni-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ replicas with automatic failover.
    docker build -t postgres-patroni .
    ```
 
+   If package downloads fail during the build, provide an alternative
+   Debian mirror:
+
+   ```bash
+   docker build --build-arg APT_MIRROR=your.mirror.example \
+       -t postgres-patroni .
+   ```
+
 2. Initialize a Docker Swarm if you have not done so already:
 
    ```bash


### PR DESCRIPTION
## Summary
- allow overriding the Debian mirror when building the Docker image
- document the new `APT_MIRROR` build argument and provide troubleshooting advice

## Testing
- `sh -n patroni-entrypoint.sh`
